### PR TITLE
Check if the arguments of the add function are numbers

### DIFF
--- a/src/arrow-function/index.js
+++ b/src/arrow-function/index.js
@@ -12,10 +12,14 @@ export function add(){
 
   var sum = 0;
   for (var i = 0; i < arguments.length; i++) {
-    if(arguments[i])
+    if(isNumber(arguments[i]))
       sum += arguments[i];
     else
       throw new Error('You can only sum numbers');
   }
   return sum;
+}
+
+function isNumber(n) {
+  return !Number.isNaN(n) && Number.isFinite(n);
 }


### PR DESCRIPTION
Hey @davyengone! Great workshop yesterday.

I found out in the `add` method that you just check for truthy values and therefore a `string` or `true` won't throw error. In the same manner a "numeric string" would be concatenated and not added. So I think using a function to check if is number and the unary plus operator to convert numeric strings will also help the following attendees with the process of converting the method to ES6.

Cheers, Pablo.
